### PR TITLE
Revert "MOD: etcd watch failed"

### DIFF
--- a/configs/configs.go
+++ b/configs/configs.go
@@ -5,8 +5,6 @@ import (
 	"database/sql"
 	"strings"
 
-	"fmt"
-
 	"github.com/coreos/etcd/clientv3"
 	v3rpc "github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
 	"github.com/coreos/etcd/mvcc/mvccpb"
@@ -191,7 +189,7 @@ func (ctrl *ConfigCtrl) Watch(ctx context.Context, appID int64, node, name strin
 		return nil, 0, utils.CleanErr(err, "", "watch key(%s) with revision(%d) fail: %v", name, revision, err)
 	}
 	if resp.Canceled || resp.Events == nil {
-		return nil, resp.Header.Revision, utils.NewError(utils.EcodeEtcdWatchFailed, fmt.Sprintf("watch key(%s) fail, no events", name))
+		return nil, resp.Header.Revision, nil
 	}
 	for _, event := range resp.Events {
 		switch event.Type {

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -45,8 +45,6 @@ const (
 	EcodeNameDuplicated = "NAME_DUPLICATED"
 	// EcodeNotPermitted NOT_PERMITTED
 	EcodeNotPermitted = "NOT_PERMITTED"
-	// EcodeEtcdWatchFailed ETCD_WATCH_FAILED
-	EcodeEtcdWatchFailed = "ETCD_WATCH_FAILED"
 )
 
 // Error error


### PR DESCRIPTION
This reverts commit 1c78ed18e2732f9cef82be52efdc61dc2b655f39.
For the moment revert the modification that  it is throw ETCD_WATCH_FAILED when watch config no events ！